### PR TITLE
Remove color override in favor of external color override

### DIFF
--- a/src/components/SearchBar.css
+++ b/src/components/SearchBar.css
@@ -23,11 +23,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background: #2a71a5;
-}
-
-.searchbar__container .searchbar__button--submit:hover {
-    background: #266594;
 }
 
 .searchbar__container .searchbar__button--submit.r4r-DEFAULT {

--- a/src/views/results/index.css
+++ b/src/views/results/index.css
@@ -126,6 +126,11 @@
     .results__filter-button.r4r-DEFAULT:hover {
         background-color: #266594;
     }
+
+    .results__filter-button.r4r-DEFAULT:focus {
+        background-color: #266594;
+    }
+
     
     .results__search-container.r4r-DEFAULT .results__filter-button.r4r-DEFAULT {
         margin-left: 30px;


### PR DESCRIPTION
Design requests have required overriding the overriding cgov button styles. That override was done in the app to be associated with the filter button that needed the matching styles, but now I'm pulling it out to make it clearer where that override action is happening.